### PR TITLE
Properly support Flask app factory pattern

### DIFF
--- a/flask_ldap3_login/__init__.py
+++ b/flask_ldap3_login/__init__.py
@@ -71,6 +71,11 @@ class LDAP3LoginManager(object):
         '''
         
         app.ldap3_login_manager = self
+
+        servers = list(self._server_pool)
+        for s in servers:
+            self._server_pool.remove(s)
+
         self.init_config(app.config)
 
         if hasattr(app, 'teardown_appcontext'):
@@ -123,7 +128,6 @@ class LDAP3LoginManager(object):
         self.config.setdefault('LDAP_GROUP_OBJECT_FILTER', '(objectclass=group)')
         self.config.setdefault('LDAP_GROUP_MEMBERS_ATTR', 'uniqueMember')
         self.config.setdefault('LDAP_GET_GROUP_ATTRIBUTES', ldap3.ALL_ATTRIBUTES)
-        
 
         self.add_server(
             hostname=self.config.get('LDAP_HOST'),

--- a/flask_ldap3_login_tests/test_ldap3_login.py
+++ b/flask_ldap3_login_tests/test_ldap3_login.py
@@ -408,4 +408,4 @@ class AppFactoryTestCase(BaseTestCase):
         """
         for i in range(10):
             self.manager.init_app(self.app)
-            self.assertIs(len(list(self.manager._server_pool)), 1)
+            self.assertEquals(len(list(self.manager._server_pool)), 1)

--- a/flask_ldap3_login_tests/test_ldap3_login.py
+++ b/flask_ldap3_login_tests/test_ldap3_login.py
@@ -394,3 +394,18 @@ class SessionContextTextCase(BaseTestCase):
             self.assertFalse(hasattr(stack.top, 'ldap3_manager_connections'))
 
 
+class AppFactoryTestCase(BaseTestCase):
+    """
+    Tests whether the popular Flask app factory pattern can be used.
+    """
+
+    def test_server_pool(self):
+        """
+        To support the app factory pattern, the server pool must be reset when
+        init_app is called.
+        The test is executed 10 times because if you e.g. run unit tests you
+        likely reinitialize the app many times.
+        """
+        for i in range(10):
+            self.manager.init_app(self.app)
+            self.assertIs(len(list(self.manager._server_pool)), 1)


### PR DESCRIPTION
This pull request adds proper support for the app factory pattern.

Since this extension provides an `init_app` function developers might think that the [app factory pattern](http://flask.pocoo.org/docs/0.10/patterns/appfactories/) can be used with it.
Unfortunately, after a lot of hours of debugging and testing, I found out that the support for it is limited. I reinitialized the app multiple times in several different unit test fixtures with different configuration values. One of these fixtures started a [python-ldap-test](https://pypi.python.org/pypi/python-ldap-test/) server and initialized the new app with the settings that the test server provided. Since the app was initialized a few times with the default settings (`ldap://localhost:389`), there were a few servers already inserted into the server pool. This caused the extension to first try to use the local instance of OpenLDAP slapd which resulted in several errors (invalid DN, invalid credentials, ...).
After I found out that there are incorrect servers in the pool, I shut down the local slapd server and suddenly it worked.
The code I added will remove all servers from the server pool before re-initializing the configuration (which adds a server to the pool that follows the Flask app configuration)