### PR TITLE
Only use search result entries to look for matching users.

### DIFF
--- a/flask_ldap3_login/__init__.py
+++ b/flask_ldap3_login/__init__.py
@@ -408,6 +408,9 @@ class LDAP3LoginManager(object):
 
         else:
             for user in connection.response:
+                if user['type'] != 'searchResEntry':
+                    continue
+
                 # Attempt to bind with each user we find until we can find 
                 # one that works.
                 user_connection = self._make_connection(

--- a/flask_ldap3_login_tests/MockTypes.py
+++ b/flask_ldap3_login_tests/MockTypes.py
@@ -116,7 +116,10 @@ class Connection(mock.MagicMock):
                 return items
 
             items = recurse_search(scoped_directory)
-            items = [dict(attributes=user, dn=user['dn']) for user in items]
+            items = [
+                dict(attributes=user, dn=user['dn'], type='searchResEntry')
+                for user in items
+            ]
             self._result = len(items) > 0
             self._response = items
 


### PR DESCRIPTION
Responses like searchResRef should be ignored.  They don't have a 'dn'.

Note: I'm no LDAP expert. I just saw in responses from our AD server that it would return searchResRef entries in connection.responses. In the case where there was no matching user, the searchResRef would be processed and a KeyError would be raised when trying to access user['dn'] because the only two keys in the dict are 'uri' and 'type'.