### PR TITLE
fix for unicode in logs

### DIFF
--- a/flask_ldap3_login/__init__.py
+++ b/flask_ldap3_login/__init__.py
@@ -302,7 +302,7 @@ class LDAP3LoginManager(object):
             response.status = AuthenticationResponseStatus.success
             response.user_id = username
             log.debug(
-                "Authentication was successful for user '{0}'".format(username))
+                u"Authentication was successful for user '{0}'".format(username))
 
             if self.config.get('LDAP_BIND_DIRECT_GET_USER_INFO'):
                 # User wants extra info about the bind
@@ -338,7 +338,7 @@ class LDAP3LoginManager(object):
 
         except ldap3.core.exceptions.LDAPInvalidCredentialsResult as e:
             log.debug(
-                "Authentication was not successful for user '{0}'".format(username))
+                u"Authentication was not successful for user '{0}'".format(username))
             response.status = AuthenticationResponseStatus.fail
         except Exception as e:
             log.error(e)
@@ -378,7 +378,7 @@ class LDAP3LoginManager(object):
         try:
             connection.bind()
             log.debug(
-                "Authentication was successful for user '{0}'".format(username))
+                u"Authentication was successful for user '{0}'".format(username))
             response.status = AuthenticationResponseStatus.success
             # Get user info here.
 
@@ -393,7 +393,7 @@ class LDAP3LoginManager(object):
 
         except ldap3.core.exceptions.LDAPInvalidCredentialsResult as e:
             log.debug(
-                "Authentication was not successful for user '{0}'".format(username))
+                u"Authentication was not successful for user '{0}'".format(username))
             response.status = AuthenticationResponseStatus.fail
         except Exception as e:
             log.error(e)
@@ -426,8 +426,8 @@ class LDAP3LoginManager(object):
 
         try:
             connection.bind()
-            log.debug("Successfully bound to LDAP as '{0}' for search_bind method".format(
-                self.config.get('LDAP_BIND_USER_DN') or 'Anonymous'
+            log.debug(u"Successfully bound to LDAP as '{0}' for search_bind method".format(
+                self.config.get('LDAP_BIND_USER_DN') or u'Anonymous'
             ))
         except Exception as e:
             self.destroy_connection(connection)
@@ -444,8 +444,8 @@ class LDAP3LoginManager(object):
             user_filter,
         )
 
-        log.debug("Performing an LDAP Search using filter '{0}', base '{1}', "
-                  "and scope '{2}'".format(
+        log.debug(u"Performing an LDAP Search using filter '{0}', base '{1}', "
+                  u"and scope '{2}'".format(
                       search_filter,
                       self.full_user_search_dn,
                       self.config.get('LDAP_USER_SEARCH_SCOPE')
@@ -466,7 +466,7 @@ class LDAP3LoginManager(object):
                 len(connection.response) > 1):
             # Don't allow them to log in.
             log.debug(
-                "Authentication was not successful for user '{0}'".format(username))
+                u"Authentication was not successful for user '{0}'".format(username))
 
         else:
             for user in connection.response:
@@ -483,12 +483,12 @@ class LDAP3LoginManager(object):
                 )
 
                 log.debug(
-                    "Directly binding a connection to a server with "
-                    "user:'{0}'".format(user['dn']))
+                    u"Directly binding a connection to a server with "
+                    u"user:'{0}'".format(user['dn']))
                 try:
                     user_connection.bind()
                     log.debug(
-                        "Authentication was successful for user '{0}'".format(username))
+                        u"Authentication was successful for user '{0}'".format(username))
                     response.status = AuthenticationResponseStatus.success
 
                     # Populate User Data
@@ -504,8 +504,8 @@ class LDAP3LoginManager(object):
 
                 except ldap3.core.exceptions.LDAPInvalidCredentialsResult as e:
                     log.debug(
-                        "Authentication was not successful for "
-                        "user '{0}'".format(username))
+                        u"Authentication was not successful for "
+                        u"user '{0}'".format(username))
                     response.status = AuthenticationResponseStatus.fail
                 except Exception as e:  # pragma: no cover
                     # This should never happen, however in case ldap3 does ever
@@ -548,8 +548,8 @@ class LDAP3LoginManager(object):
             user_dn=dn
         )
 
-        log.debug("Searching for groups for specific user with filter '{0}' "
-                  ", base '{1}' and scope '{2}'".format(
+        log.debug(u"Searching for groups for specific user with filter '{0}' "
+                  u", base '{1}' and scope '{2}'".format(
                       search_filter,
                       group_search_dn or self.full_group_search_dn,
                       self.config.get('LDAP_GROUP_SEARCH_SCOPE')
@@ -767,8 +767,8 @@ class LDAP3LoginManager(object):
             authentication = getattr(ldap3, self.config.get(
                 'LDAP_BIND_AUTHENTICATION_TYPE'))
 
-        log.debug("Opening connection with bind user '{0}'".format(
-            bind_user or 'Anonymous'))
+        log.debug(u"Opening connection with bind user '{0}'".format(
+            bind_user or u'Anonymous'))
         connection = ldap3.Connection(
             server=self._server_pool,
             read_only=self.config.get('LDAP_READONLY'),


### PR DESCRIPTION
Hi,
I experienced some encode errors while working on LDAP entries containing special characters like umlauts. So, I made sure that the every related logging string is defined as unicode.