### PR TITLE
Fixes get_user_groups for user dn that must be escaped to be used in …

### DIFF
--- a/flask_ldap3_login/__init__.py
+++ b/flask_ldap3_login/__init__.py
@@ -549,10 +549,11 @@ class LDAP3LoginManager(object):
             )
             connection.bind()
 
+        safe_dn = ldap3.utils.conv.escape_filter_chars(dn)
         search_filter = '(&{group_filter}({members_attr}={user_dn}))'.format(
             group_filter=self.config.get('LDAP_GROUP_OBJECT_FILTER'),
             members_attr=self.config.get('LDAP_GROUP_MEMBERS_ATTR'),
-            user_dn=dn
+            user_dn=safe_dn
         )
 
         log.debug("Searching for groups for specific user with filter '{0}' "


### PR DESCRIPTION
…a filter
Found a problem with user dn's that have chars that cannot be in a filter.   For instance "cn=Firstname (admin) Lastname, ..." causes filters to not work due to the ().   

This patch should fix the problem.
 