### PR TITLE
Update ldap_noapp_tls.py example (cosmetic)

### DIFF
--- a/ldap_noapp_tls.py
+++ b/ldap_noapp_tls.py
@@ -53,10 +53,7 @@ ldap_manager.init_config(config)
 tls_ctx = Tls(
     validate=ssl.CERT_REQUIRED,
     version=ssl.PROTOCOL_TLSv1,
-    ca_certs_file='/path/to/cacerts',
-    valid_names=[
-        'ad.mydomain.com',
-    ]
+    ca_certs_file='/path/to/cacerts'
 )
 
 ldap_manager.add_server(


### PR DESCRIPTION
valid_names is not part of the Tls object, hence the following code is misleading

tls_ctx = Tls(
 valid_names = ['hostname']
)

Check LDAP3 documentation for Tls object. Or, you can try putting fake names in this list and it will still successfully establish TLS session.

It is a cosmetic change, as existing code doesn't affect functionality (is simply ignored) but is indeed misleading as I spent some time trying to find out valid_names attribute in LDAP3 API.