### PR TITLE
Run tests on Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
 
 install:
   - pip install coveralls flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37,pypy3,lint,docs,coverage-combine
+envlist = py35,py36,py37,py38,pypy3,lint,docs,coverage-combine
 
 [testenv]
 deps =
@@ -27,7 +27,7 @@ commands =
 basepython = python3.7
 skip_install = true
 deps = coverage
-depends = py35,py36,py37,pypy3
+depends = py35,py36,py37,py38,pypy3
 parallel_show_output = true
 commands =
     coverage combine


### PR DESCRIPTION
Since Python 3.8 has been released, start running the tests there.