### PR TITLE
bump dev deps

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-flake8==3.8.4
-black==20.8b1
-flake8-black==0.2.1
-flake8-isort==4.0.0
+black==21.11b1
+flake8==4.0.1
+flake8-black==0.2.3
+flake8-isort==4.1.1

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,9 @@
-sphinx
-sphinxcontrib-napoleon
-pallets-sphinx-themes
+Pallets-Sphinx-Themes==2.0.2
+Sphinx==4.3.0
+sphinxcontrib-applehelp==1.0.2
+sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.0
+sphinxcontrib-jsmath==1.0.1
+sphinxcontrib-napoleon==0.7
+sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-serializinghtml==1.1.5


### PR DESCRIPTION
As discussed in https://github.com/nickw444/flask-ldap3-login/pull/100, this PR bumps the dev + docs dependencies.

I've personally been using Pipenv in my other python lib repos, which works well for automatically pinning, but obviously does increase the barrier to entry when contributing. Maybe worth considering? 

https://github.com/nickw444/nessclient/blob/e0916e5fa6b76d436cfa0b47a006133071275ea8/Pipfile#L8-L11