### PR TITLE
Include artifacts in Github Release

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -108,3 +108,4 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           generate_release_notes: true
+          files: dist/*


### PR DESCRIPTION
As the title says, publish the actual artifacts to the release page on Github too.

As seen here: https://github.com/nickw444/nickw-flask-utils/releases/tag/1.2.4