### PR TITLE
Adding Mock LDAP Functionality for improved testing

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -27,8 +27,6 @@ Core
                                          Useful for running unit tests.
                                          The value is used to point to a json
                                          entries file to load data to the DIT.
-                                         This path is relative to the Flask
-                                         ``app.instance_path`` if initialized with an app.
                                          Defaults to ``None`` (no mocking).
 
 ``LDAP_USE_SSL``                         Specifies whether the default server

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -13,10 +13,23 @@ Core
                                          connecting to LDAP. Defaults to 
                                          ``389``.
 
-``LDAP_HOST``                            Speficies the address of the server to
-                                         connect to by default. ``None``.
+``LDAP_HOST``                            Specifies the address of the default
+                                         server to use when connecting to LDAP.
                                          Additional servers can be added via the
                                          ``add_server`` method.
+                                         Defaults to ``None``.
+
+``LDAP_MOCK_DATA``                       If specified, configures
+                                         ``ldap3.Connection`` with
+                                         ``client_strategy=MOCK_SYNC`` to setup
+                                         testing with a mock LDAP connection.
+                                         [#ldap3mock]_
+                                         Useful for running unit tests.
+                                         The value is used to point to a json
+                                         entries file to load data to the DIT.
+                                         This path is relative to the Flask
+                                         ``app.instance_path`` if initialized with an app.
+                                         Defaults to ``None`` (no mocking).
 
 ``LDAP_USE_SSL``                         Specifies whether the default server
                                          connection should use SSL. Defaults to
@@ -160,3 +173,7 @@ Filters/Searching
                                      Defaults to ``ldap3.ALL_ATTRIBUTES``       
 
 ==================================== ================================================
+
+
+.. [#ldap3mock] For details about mocking the ldap3.Connection,
+   see `Mocking -- ldap3 documentation <https://ldap3.readthedocs.io/en/latest/mocking.html>`_

--- a/flask_ldap3_login/__init__.py
+++ b/flask_ldap3_login/__init__.py
@@ -814,7 +814,8 @@ class LDAP3LoginManager:
 
         if current_app.config.get("LDAP_MOCK_DATA") is not None:
             # TODO: Should use current_app.instance_path relative path
-            #  or app.open_instance_resource to open file
+            #  or app.open_instance_resource to open file, but entries_from_json
+            #  expects a filename to open, not file data.
             log.info(
                 "Loading LDAP_MOCK_DATA from: {}".format(
                     current_app.config.get("LDAP_MOCK_DATA")

--- a/flask_ldap3_login/__init__.py
+++ b/flask_ldap3_login/__init__.py
@@ -47,6 +47,7 @@ _CONFIG_DEFAULTS = [
     ("LDAP_GROUP_MEMBERS_ATTR", "uniqueMember"),
     ("LDAP_GET_GROUP_ATTRIBUTES", ldap3.ALL_ATTRIBUTES),
     ("LDAP_ADD_SERVER", True),
+    ("LDAP_MOCK_DATA", None),
 ]
 
 
@@ -784,20 +785,44 @@ class LDAP3LoginManager:
                 ldap3, current_app.config.get("LDAP_BIND_AUTHENTICATION_TYPE")
             )
 
+        if current_app.config.get("LDAP_MOCK_DATA") is None:
+            strategy = ldap3.SYNC
+            server_arg = app.ldap3_login_manager_server_pool
+        else:
+            log.info("Using MOCK_SYNC")
+            strategy = ldap3.MOCK_SYNC
+            # This is needed because using MOCK with ServerPool is broken,
+            # see https://github.com/cannatag/ldap3/issues/1007
+            server_arg = ldap3.Server("fake_server")
+
         log.debug(
-            "Opening connection with bind user '{}'".format(bind_user or "Anonymous")
+            "Opening connection with bind user '{}' [{}]".format(
+                bind_user or "Anonymous", strategy
+            )
         )
         connection = ldap3.Connection(
-            server=app.ldap3_login_manager_server_pool,
+            server=server_arg,
             read_only=current_app.config.get("LDAP_READONLY"),
             user=bind_user,
             password=bind_password,
-            client_strategy=ldap3.SYNC,
+            client_strategy=strategy,
             authentication=authentication,
             check_names=current_app.config["LDAP_CHECK_NAMES"],
             raise_exceptions=True,
             **kwargs
         )
+
+        if current_app.config.get("LDAP_MOCK_DATA") is not None:
+            # TODO: Should use current_app.instance_path relative path
+            #  or app.open_instance_resource to open file
+            log.info(
+                "Loading LDAP_MOCK_DATA from: {}".format(
+                    current_app.config.get("LDAP_MOCK_DATA")
+                )
+            )
+            connection.strategy.entries_from_json(
+                current_app.config.get("LDAP_MOCK_DATA")
+            )
 
         if contextualise:
             self._contextualise_connection(connection)

--- a/flask_ldap3_login_tests/Directory.py
+++ b/flask_ldap3_login_tests/Directory.py
@@ -98,11 +98,7 @@ def get_directory_base(dn):
 def key_path_recurse(d, path=None):
     """Used by `dump_directory_to_file` to flatten DIRECTORY"""
     keys = d.keys()
-    if (
-        len(list(filter(lambda k: "=" in k, keys))) == 0
-    ):  # The keys are clearly attributes, return them.
-        return {"dn": path, "raw": d}
-    else:
+    if any("=" in k for k in d):  # If any keys have "=", assume they are paths.
         result = list()
         for k in keys:
             new_path = ",".join([k, path]) if path else k
@@ -114,6 +110,8 @@ def key_path_recurse(d, path=None):
             else:
                 raise ValueError("Unexpected type for key result: {}".format(kres))
         return result
+    else:  # Otherwise, assume it's the attributes.
+        return {"dn": path, "raw": d}
 
 
 def dump_directory_to_file(filename):

--- a/flask_ldap3_login_tests/Directory.py
+++ b/flask_ldap3_login_tests/Directory.py
@@ -1,3 +1,5 @@
+import json
+
 import ldap3
 
 DIRECTORY = {
@@ -9,6 +11,7 @@ DIRECTORY = {
                 "objectclass": ["person"],
                 "dn": "cn=Bind,dc=mydomain,dc=com",
                 "password": "bind123",
+                "userPassword": "bind123",
             },
             "ou=users": {
                 "cn=Nick Whyte": {
@@ -90,3 +93,34 @@ def get_directory_base_recurse(location, directory):
 def get_directory_base(dn):
     location = list(reversed(dn.split(",")))
     return get_directory_base_recurse(location, directory=DIRECTORY)
+
+
+def key_path_recurse(d, path=None):
+    """Used by `dump_directory_to_file` to flatten DIRECTORY"""
+    keys = d.keys()
+    if (
+        len(list(filter(lambda k: "=" in k, keys))) == 0
+    ):  # The keys are clearly attributes, return them.
+        return {"dn": path, "raw": d}
+    else:
+        result = list()
+        for k in keys:
+            new_path = ",".join([k, path]) if path else k
+            kres = key_path_recurse(d[k], path=new_path)
+            if isinstance(kres, list):
+                result.extend(kres)
+            elif isinstance(kres, dict):
+                result.append(kres)
+            else:
+                raise ValueError("Unexpected type for key result: {}".format(kres))
+        return result
+
+
+def dump_directory_to_file(filename):
+    """
+    Reformat the test directory data to a format used
+    by ldap3.MockBaseStrategy.entries_from_json and save it to filename
+    """
+    entries = key_path_recurse(DIRECTORY)
+    with open(filename, "w") as outfile:
+        json.dump({"entries": entries}, outfile, indent=2)


### PR DESCRIPTION
Hello,

As described in #28, I've added an option `LDAP_MOCK_DATA` that, when not `None` (default), will implement a Mock connection, instead of a real connection.  This "mocking" is described in detail in the Python [ldap3 package page on Mocking](https://ldap3.readthedocs.io/en/latest/mocking.html).

Minimal changes were made in the package code to setup the connection using a different strategy.  Due to a problem with how the connection is setup with a ServerPool (see cannatag/ldap3#1007) a fake Server object is also created and used for the connection, ignoring the established ServerPool object for the extension.

Additional changes were needed in order to setup unit tests, including dumping the test "directory" to a JSON file to be used to load entries into the mock server DIT.  There is also a difference between the schema used by the test directory information and what is used and returned by ldap3 during mocking, so a slight modification to the test directory was made.  For a cleaner or more long term solution, the structure of the test directory might be modified to match the ldap3 mock implementation or the schema on the mock ldap3 implementation could be better modeled.  In theory, all tests could start using the ldap3 mock instead of the existing mock.

I originally intended to use the Flask app instance directory for the relative import of the mock data, but found that adding this relative import required too much additional overhead.  I believe that the import is relative to the current working directory of the Python thread, but unsure if this is always the case.  Users of flask-ldap3-login should specify LDAP_MOCK_DATA using an absolute path or may want to do some trial and error to determine how to load data.

Thank you for considering this PR!!!  I'm open to further modifications for improvements on this feature.