### PR TITLE
Adding None check on teardown

### DIFF
--- a/flask_ldap3_login/__init__.py
+++ b/flask_ldap3_login/__init__.py
@@ -198,7 +198,7 @@ class LDAP3LoginManager:
             if hasattr(ctx, "ldap3_manager_connections"):
                 for connection in ctx.ldap3_manager_connections:
                     self.destroy_connection(connection)
-            if hasattr(ctx, "ldap3_manager_main_connection"):
+            if hasattr(ctx, "ldap3_manager_main_connection") and ctx.ldap3_manager_main_connection is not None:
                 log.debug("Unbinding a connection used within the request context.")
                 ctx.ldap3_manager_main_connection.unbind()
                 ctx.ldap3_manager_main_connection = None


### PR DESCRIPTION
It is possible for the attribute "ldap3_manager_main_connection" might exist in the context, but the value to be `None`.  In particular, this can happen during unit tests while using mock functionality.  This check prevents attempting to unbind a `None` value. 