### PR TITLE
fix type checks in MockTypes

### DIFF
--- a/flask_ldap3_login_tests/MockTypes.py
+++ b/flask_ldap3_login_tests/MockTypes.py
@@ -53,7 +53,7 @@ def build_comparison(cmp_string):
             field, value = match.group(1, 2)
 
             def lamb(data):
-                return data is dict and field in data and value in data[field]
+                return isinstance(data, dict) and field in data and value in data[field]
 
             return lamb
         else:
@@ -132,7 +132,7 @@ class Connection(mock.MagicMock):
                     if check_user(item):
                         items.append(item)
 
-                    if item is dict:
+                    if isinstance(item, dict):
                         items.extend(recurse_search(item))
 
                 return items


### PR DESCRIPTION
This fixes the failing tests from PR #117.

I wrongly used is instead of instanceof in 3f95ca11ec17d9d9bd978082e4db0ea0918fea11

I also enabled Actions in my repo and all actions pass: https://github.com/m-bach/flask-ldap3-login/actions/runs/7827759580