### PR TITLE
update github actions

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -8,8 +8,8 @@ jobs:
     name: "Lint"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
       - name: 'Install Dependencies'
@@ -25,8 +25,8 @@ jobs:
     name: "Build Docs"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
       - name: 'Install Dependencies'
@@ -52,8 +52,8 @@ jobs:
             toxenv: py311
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: 'Install Dependencies'
@@ -71,7 +71,7 @@ jobs:
         run: |
           git describe --tags --exact-match > VERSION || true
           python setup.py sdist bdist_wheel
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         # Only publish artifacts from Python latest build.
         if: ${{ matrix.python-version == '3.11' }}
         with:
@@ -88,7 +88,7 @@ jobs:
       - lint
     if: startsWith(github.ref, 'refs/tags')
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
The github actions in the workflow are outdated and use outdated node versions.

I updated all actions to their newest version and tested running them and don't see any problems with it.